### PR TITLE
Fixes #13: Add validation handler to 3 post requests 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 '''
 Flask Application
 '''
-from dataclasses import asdict
 from typing import List, Dict, Any
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill

--- a/app.py
+++ b/app.py
@@ -105,11 +105,11 @@ def education():
 
     def handle_put():
         request_data = request.get_json()
-        index = request.args.get('index', type=int)
+        index = request_data.get('id') or request_data.get('index')
         if index is not None and 0 <= index < len(data['education']):
-            updated_education = Education(**request_data)
+            updated_education = Education(**request_data.get('education'))
             data['education'][index] = updated_education
-            return jsonify(id=index, experience=updated_education), 200
+            return jsonify(id=index, education=updated_education), 200
 
         return jsonify({}), 404
 
@@ -161,11 +161,11 @@ def skill():
 
     def handle_put():
         request_data = request.get_json()
-        index = request.args.get('index', type=int)
+        index = request_data.get('id') or request_data.get('index')
         if index is not None and 0 <= index < len(data['skill']):
-            updated_skill = Education(**request_data)
+            updated_skill = Skill(**request_data.get('skill'))
             data['skill'][index] = updated_skill
-            return jsonify(id=index, experience=updated_skill), 200
+            return jsonify(id=index, skill=updated_skill), 200
         return jsonify({}), 404
 
     def handle_delete():

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 '''
 Flask Application
 '''
+from dataclasses import asdict
+from typing import List, Dict, Any
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
 
@@ -30,6 +32,14 @@ data = {
     ]
 }
 
+def validate_fields(required_fields: List[str], request_data: Dict[str, Any]) -> tuple:
+    '''
+    Validate that all the required fields are present in the request data
+    '''
+    missing_fields = [field for field in required_fields if field not in request_data]
+    if missing_fields: 
+        return False, f"Missing required fields: {', '.join(missing_fields)}"
+    return True, ""
 
 @app.route('/test')
 def hello_world():
@@ -48,9 +58,21 @@ def experience():
         return jsonify()
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["title", "company", "start_date", "end_date", "description", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
 
-    return jsonify({})
+        if not is_valid: 
+            return jsonify({"error": error_mssg}), 400
+
+        try: 
+            new_experience = Experience(**request_data)
+            data["experience"].append(new_experience)
+            return jsonify(asdict(new_experience)), 201
+        except TypeError as e: 
+            return jsonify({"error": str(e)}), 400
+
+    return jsonify({}), 405
 
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
@@ -61,9 +83,20 @@ def education():
         return jsonify({})
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["course", "school", "start_date", "end_date", "grade", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
 
-    return jsonify({})
+        if not is_valid:
+            return jsonify({"error": error_mssg}), 400
+        try: 
+            new_education = Education(**request_data)
+            data["education"].append(new_education)
+            return jsonify(asdict(new_education)), 201
+        except TypeError as e:
+            return jsonify({"error": str(e)}), 400
+
+    return jsonify({}), 405
 
 
 @app.route('/resume/skill', methods=['GET', 'POST'])
@@ -75,6 +108,17 @@ def skill():
         return jsonify({})
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["name", "proficiency", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
 
-    return jsonify({})
+        if not is_valid:
+            return jsonify({"error": error_mssg}), 400
+        try: 
+            new_skill = Skill(**request_data)
+            data["skill"].append(new_skill)
+            return jsonify(asdict(new_skill)), 201
+        except TypeError as e:
+            return jsonify({"error": str(e)}), 400
+
+    return jsonify({}), 405

--- a/app.py
+++ b/app.py
@@ -82,13 +82,14 @@ def education():
     '''
     Handles education requests
     '''
-    if request.method == 'GET':
+
+    def handle_get():
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['education']):
             return jsonify(data['education'][index])
         return jsonify(data['education'])
 
-    if request.method == 'POST':
+    def handle_post():
         request_data = request.get_json()
         required_fields = ["course", "school", "start_date", "end_date", "grade", "logo"]
         is_valid, error_mssg = validate_fields(required_fields, request_data)
@@ -102,7 +103,7 @@ def education():
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
 
-    if request.method == 'PUT':
+    def handle_put():
         request_data = request.get_json()
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['education']):
@@ -110,26 +111,37 @@ def education():
             data['education'][index] = updated_education
             return jsonify(id=index, experience=updated_education), 200
 
-    if request.method == 'DELETE':
+        return jsonify({}), 404
+
+    def handle_delete():
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['education']):
             deleted_education = data['education'].pop(index)
             return jsonify(deleted_education), 200
 
-    return jsonify({}), 405
+        return jsonify({}), 404
+
+    handlers = {
+        'GET': handle_get,
+        'POST': handle_post,
+        'PUT': handle_put,
+        'DELETE': handle_delete
+    }
+    return handlers[request.method](), 405
 
 @app.route('/resume/skill', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def skill():
     '''
     Handles Skill requests
     '''
-    if request.method == 'GET':
+
+    def handle_get():
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['skill']):
             return jsonify(data['skill'][index])
         return jsonify(data['skill'])
 
-    if request.method == 'POST':
+    def handle_post():
         request_data = request.get_json()
         required_fields = ["name", "proficiency", "logo"]
         is_valid, error_mssg = validate_fields(required_fields, request_data)
@@ -143,18 +155,30 @@ def skill():
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
 
-    if request.method == 'PUT':
+    def handle_put():
         request_data = request.get_json()
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['skill']):
             updated_skill = Education(**request_data)
             data['skill'][index] = updated_skill
             return jsonify(id=index, experience=updated_skill), 200
+        return jsonify({}), 404
 
-    if request.method == 'DELETE':
+    def handle_delete():
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['skill']):
             deleted_skill = data['skill'].pop(index)
             return jsonify(deleted_skill), 200
+        return jsonify({}), 404
+
+    methods = {
+        'GET': handle_get,
+        'POST': handle_post,
+        'PUT': handle_put,
+        'DELETE': handle_delete
+    }
+    handler = methods.get(request.method)
+    if handler:
+        return handler()
 
     return jsonify({}), 405

--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def experience():
         try:
             new_experience = Experience(**request_data)
             data["experience"].append(new_experience)
-            return jsonify(asdict(new_experience)), 201
+            return jsonify(experience=new_experience, id=len(data['experience'])-1), 201
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
 
@@ -99,7 +99,7 @@ def education():
         try:
             new_education = Education(**request_data)
             data["education"].append(new_education)
-            return jsonify(asdict(new_education)), 201
+            return jsonify(education=new_education, id=len(data['education'])-1), 201
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
 
@@ -121,13 +121,17 @@ def education():
 
         return jsonify({}), 404
 
-    handlers = {
+    methods = {
         'GET': handle_get,
         'POST': handle_post,
         'PUT': handle_put,
         'DELETE': handle_delete
     }
-    return handlers[request.method](), 405
+    handler = methods.get(request.method)
+    if handler:
+        return handler()
+
+    return jsonify({}), 405
 
 @app.route('/resume/skill', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def skill():
@@ -151,7 +155,7 @@ def skill():
         try:
             new_skill = Skill(**request_data)
             data["skill"].append(new_skill)
-            return jsonify(asdict(new_skill)), 201
+            return jsonify(skill=new_skill, id=len(data['skill'])-1), 201
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
 

--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ def validate_fields(required_fields: List[str], request_data: Dict[str, Any]) ->
     Validate that all the required fields are present in the request data
     '''
     missing_fields = [field for field in required_fields if field not in request_data]
-    if missing_fields: 
+    if missing_fields:
         return False, f"Missing required fields: {', '.join(missing_fields)}"
     return True, ""
 
@@ -65,14 +65,14 @@ def experience():
         required_fields = ["title", "company", "start_date", "end_date", "description", "logo"]
         is_valid, error_mssg = validate_fields(required_fields, request_data)
 
-        if not is_valid: 
+        if not is_valid:
             return jsonify({"error": error_mssg}), 400
 
-        try: 
+        try:
             new_experience = Experience(**request_data)
             data["experience"].append(new_experience)
             return jsonify(asdict(new_experience)), 201
-        except TypeError as e: 
+        except TypeError as e:
             return jsonify({"error": str(e)}), 400
 
     return jsonify({}), 405
@@ -95,7 +95,7 @@ def education():
 
         if not is_valid:
             return jsonify({"error": error_mssg}), 400
-        try: 
+        try:
             new_education = Education(**request_data)
             data["education"].append(new_education)
             return jsonify(asdict(new_education)), 201
@@ -118,7 +118,6 @@ def education():
 
     return jsonify({}), 405
 
-
 @app.route('/resume/skill', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def skill():
     '''
@@ -137,7 +136,7 @@ def skill():
 
         if not is_valid:
             return jsonify({"error": error_mssg}), 400
-        try: 
+        try:
             new_skill = Skill(**request_data)
             data["skill"].append(new_skill)
             return jsonify(asdict(new_skill)), 201

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -179,7 +179,7 @@ def test_edit_education():
         "logo": "example-logo.png"
     }
 
-    post_response = app.test_client().post('/resume/eudcation',
+    post_response = app.test_client().post('/resume/education',
                                      json=example_education)
     item_id = post_response.json['id']
 
@@ -193,8 +193,8 @@ def test_edit_education():
     }
 
     response = app.test_client().put('/resume/education',
-                                     json={"experience": updated_education, "id": item_id})
-    assert response.json['experience'] == updated_education
+                                     json={"education": updated_education, "id": item_id})
+    assert response.json['education'] == updated_education
     assert response.json['id'] == item_id
     assert response.status_code == 200
 
@@ -222,8 +222,8 @@ def test_edit_skill():
     }
 
     response = app.test_client().put('/resume/skill',
-                                     json={"experience": updated_skill, "id": item_id})
-    assert response.json['experience'] == updated_skill
+                                     json={"skill": updated_skill, "id": item_id})
+    assert response.json['skill'] == updated_skill
     assert response.json['id'] == item_id
     assert response.status_code == 200
 

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -33,6 +33,36 @@ def test_experience():
     response = app.test_client().get('/resume/experience')
     assert response.json[item_id] == example_experience
 
+def test_experience_post_success():
+    """
+    Test the successful creation of a new experience entry.
+    """
+    new_experience = {
+        "title": "Software Engineer",
+        "company": "Tech Corp",
+        "start_date": "January 2023",
+        "end_date": "Present",
+        "description": "Full stack development",
+        "logo": "tech-corp-logo.png"
+    }
+    response = app.test_client().post('/resume/experience',
+                           json=new_experience)
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_experience[key] == value
+
+def test_experience_post_missing_fields():
+    """
+    Test the unsuccessful creation of a new experience entry because of missing fields.
+    """
+    incomplete_experience = {
+        "title": "Data Engineer",
+        "company": "Google"
+    }
+    response = app.test_client().post('/resume/experience', 
+                           json=incomplete_experience)
+    assert response.status_code == 400
+    assert 'error' in response.json
 
 def test_education():
     '''
@@ -54,6 +84,38 @@ def test_education():
     response = app.test_client().get('/resume/education')
     assert response.json[item_id] == example_education
 
+def test_post_education_success():
+    """
+    Test the successful creation of a new education entry.
+    """
+    new_education = {
+        "course": "Master's in Computer Science",
+        "school": "Tech University",
+        "start_date": "September 2022",
+        "end_date": "June 2024",
+        "grade": "3.8 GPA",
+        "logo": "tech-uni-logo.png"
+    }
+    response = app.test_client().post('/resume/education', 
+                            json=new_education,
+                            content_type='application/json')
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_education[key] == value
+
+def test_post_education_missing_fields():
+    """
+    Test the unsuccessful creation of a new education entry because of missing fields.
+    """
+    incomplete_education = {
+        "course": "PhD in Computer Science",
+        "school": "Cornell University"
+    }
+    response = app.test_client().post('/resume/education', 
+                            json=incomplete_education,
+                            content_type='application/json')
+    assert response.status_code == 400
+    assert 'error' in response.json
 
 def test_skill():
     '''
@@ -72,3 +134,32 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+def test_post_skill_success():
+    """
+    Test the successful creation of a new post entry.
+    """
+    new_skill = {
+        "name": "JavaScript",
+        "proficiency": "3-4 Years",
+        "logo": "js-logo.png"
+    }
+    response = app.test_client().post('/resume/skill', 
+                            json=new_skill,
+                            content_type='application/json')
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_skill[key] == value
+
+def test_post_skill_missing_fields():
+    """
+    Test the unsuccessful creation of a new skill entry because of missing fields.
+    """
+    incomplete_skill = {
+        "name": "JavaScript"
+    }
+    response = app.test_client().post('/resume/skill', 
+                            json=incomplete_skill,
+                            content_type='application/json')
+    assert response.status_code == 400
+    assert 'error' in response.json

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -48,7 +48,7 @@ def test_experience_post_success():
     response = app.test_client().post('/resume/experience',
                            json=new_experience)
     assert response.status_code == 201
-    for key, value in response.json.items():
+    for key, value in response.json['experience'].items():
         assert new_experience[key] == value
 
 def test_experience_post_missing_fields():
@@ -100,7 +100,7 @@ def test_post_education_success():
                             json=new_education,
                             content_type='application/json')
     assert response.status_code == 201
-    for key, value in response.json.items():
+    for key, value in response.json['education'].items():
         assert new_education[key] == value
 
 def test_post_education_missing_fields():
@@ -148,7 +148,7 @@ def test_post_skill_success():
                             json=new_skill,
                             content_type='application/json')
     assert response.status_code == 201
-    for key, value in response.json.items():
+    for key, value in response.json['skill'].items():
         assert new_skill[key] == value
 
 def test_post_skill_missing_fields():

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -162,4 +162,4 @@ def test_post_skill_missing_fields():
                             json=incomplete_skill,
                             content_type='application/json')
     assert response.status_code == 400
-    assert 'error' in response.json
+    assert 'error' in response.jso

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -59,7 +59,7 @@ def test_experience_post_missing_fields():
         "title": "Data Engineer",
         "company": "Google"
     }
-    response = app.test_client().post('/resume/experience', 
+    response = app.test_client().post('/resume/experience',
                            json=incomplete_experience)
     assert response.status_code == 400
     assert 'error' in response.json
@@ -96,7 +96,7 @@ def test_post_education_success():
         "grade": "3.8 GPA",
         "logo": "tech-uni-logo.png"
     }
-    response = app.test_client().post('/resume/education', 
+    response = app.test_client().post('/resume/education',
                             json=new_education,
                             content_type='application/json')
     assert response.status_code == 201
@@ -111,7 +111,7 @@ def test_post_education_missing_fields():
         "course": "PhD in Computer Science",
         "school": "Cornell University"
     }
-    response = app.test_client().post('/resume/education', 
+    response = app.test_client().post('/resume/education',
                             json=incomplete_education,
                             content_type='application/json')
     assert response.status_code == 400
@@ -144,7 +144,7 @@ def test_post_skill_success():
         "proficiency": "3-4 Years",
         "logo": "js-logo.png"
     }
-    response = app.test_client().post('/resume/skill', 
+    response = app.test_client().post('/resume/skill',
                             json=new_skill,
                             content_type='application/json')
     assert response.status_code == 201
@@ -158,7 +158,7 @@ def test_post_skill_missing_fields():
     incomplete_skill = {
         "name": "JavaScript"
     }
-    response = app.test_client().post('/resume/skill', 
+    response = app.test_client().post('/resume/skill',
                             json=incomplete_skill,
                             content_type='application/json')
     assert response.status_code == 400
@@ -284,4 +284,3 @@ def test_education_delete_index():
 
     response_items = app.test_client().get('/resume/education')
     assert response_items.json is None
-    


### PR DESCRIPTION
Resolves #13, #4, #8, #10
 
* Create a function validate_fields: 
  * Inputs: required_fields, request_data
  * Output: boolean, error_message

* In each of the post requests: 
  * Check whether it has all the required fields using the function above 
  * If it is, then add that new request into data object 
  * Return the json object back to frontend accordingly

* Add 6 test cases for 3 post requests:
  * One test case for successful creation of a new entry 
  * One test case for unsuccessful creation because of missing fields 