### PR TITLE
Fixes #6, #9, #12 route to get specific index

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,9 @@ def experience():
     Handle experience requests
     '''
     if request.method == 'GET':
+        index = request.args.get('index', type=int)
+        if index and 0 <= index < len(data['experience']):
+            return jsonify(data['experience'][index])
         return jsonify(data['experience'])
 
     if request.method == 'POST':
@@ -58,6 +61,9 @@ def education():
     Handles education requests
     '''
     if request.method == 'GET':
+        index = request.args.get('index', type=int)
+        if index and 0 <= index < len(data['education']):
+            return jsonify(data['education'][index])
         return jsonify(data['education'])
 
     if request.method == 'POST':
@@ -72,6 +78,9 @@ def skill():
     Handles Skill requests
     '''
     if request.method == 'GET':
+        index = request.args.get('index', type=int)
+        if index and 0 <= index < len(data['skill']):
+            return jsonify(data['skill'][index])
         return jsonify(data['skill'])
 
     if request.method == 'POST':


### PR DESCRIPTION
Resolves Issues #6 #9 #12.

This adds an index query parameter for all cases:
BaseURL/resume/skill?index=
BaseURL/resume/education?index=
BaseURL/resume/experience?index=

Note: if the index is not given or out of range currently returning all skills, experience, or education.
Possible improvement: If wanted add an error message if the index is out of range.