### PR TITLE
 Fixes #18 #19 Delete path for indexed skills and education

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,7 @@ def experience():
     '''
     if request.method == 'GET':
         index = request.args.get('index', type=int)
-        if index and 0 <= index < len(data['experience']):
+        if index is not None and 0 <= index < len(data['experience']):
             return jsonify(data['experience'][index])
         return jsonify(data['experience'])
 
@@ -55,14 +55,14 @@ def experience():
 
     return jsonify({})
 
-@app.route('/resume/education', methods=['GET', 'POST', 'PUT'])
+@app.route('/resume/education', methods=['GET', 'POST', 'DELETE', 'PUT'])
 def education():
     '''
     Handles education requests
     '''
     if request.method == 'GET':
         index = request.args.get('index', type=int)
-        if index and 0 <= index < len(data['education']):
+        if index is not None and 0 <= index < len(data['education']):
             return jsonify(data['education'][index])
         return jsonify(data['education'])
 
@@ -78,17 +78,24 @@ def education():
             return jsonify(id=index, experience=updated_education), 200
         return jsonify({"error": "Invalid ID"}), 404
 
+    if request.method == 'DELETE':
+        index = request.args.get('index', type=int)
+        if index is not None and 0 <= index < len(data['education']):
+            deleted_education = data['education'].pop(index)
+            return jsonify(deleted_education), 200
+        return jsonify({'error': 'Education not found'}), 404
+
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST', 'PUT'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def skill():
     '''
     Handles Skill requests
     '''
     if request.method == 'GET':
         index = request.args.get('index', type=int)
-        if index and 0 <= index < len(data['skill']):
+        if index is not None and 0 <= index < len(data['skill']):
             return jsonify(data['skill'][index])
         return jsonify(data['skill'])
 
@@ -103,5 +110,12 @@ def skill():
             data['skill'][index] = updated_skill
             return jsonify(id=index, experience=updated_skill), 200
         return jsonify({"error": "Invalid ID"}), 404
+
+    if request.method == 'DELETE':
+        index = request.args.get('index', type=int)
+        if index is not None and 0 <= index < len(data['skill']):
+            deleted_skill = data['skill'].pop(index)
+            return jsonify(deleted_skill), 200
+        return jsonify({'error': 'Skills not found'}), 404
 
     return jsonify({})

--- a/app.py
+++ b/app.py
@@ -76,14 +76,12 @@ def education():
             updated_education = Education(**request_data)
             data['education'][index] = updated_education
             return jsonify(id=index, experience=updated_education), 200
-        return jsonify({"error": "Invalid ID"}), 404
 
     if request.method == 'DELETE':
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['education']):
             deleted_education = data['education'].pop(index)
             return jsonify(deleted_education), 200
-        return jsonify({'error': 'Education not found'}), 404
 
     return jsonify({})
 
@@ -109,13 +107,11 @@ def skill():
             updated_skill = Education(**request_data)
             data['skill'][index] = updated_skill
             return jsonify(id=index, experience=updated_skill), 200
-        return jsonify({"error": "Invalid ID"}), 404
 
     if request.method == 'DELETE':
         index = request.args.get('index', type=int)
         if index is not None and 0 <= index < len(data['skill']):
             deleted_skill = data['skill'].pop(index)
             return jsonify(deleted_skill), 200
-        return jsonify({'error': 'Skills not found'}), 404
 
     return jsonify({})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -135,7 +135,7 @@ def test_edit_skill():
     assert response.json['experience'] == updated_skill
     assert response.json['id'] == item_id
     assert response.status_code == 200
-    
+
 def test_skills_delete_index():
     """
     Test the successful deletion of skills entries at index.

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -136,3 +136,61 @@ def test_edit_skill():
     assert response.json['id'] == item_id
     assert response.status_code == 200
     
+def test_skills_delete_index():
+    """
+    Test the successful deletion of skills entries at index.
+    """
+    example_skills = [
+    {
+        "name": "JavaScript",
+        "proficiency": "2-4 years",
+        "logo": "example-logo.png"
+    },
+    {
+        "name": "TypeScript",
+        "proficiency": "1-3 years",
+        "logo": "example-logo.png"
+    }]
+
+    item_id = app.test_client().post('/resume/skill',
+                                     json=example_skills).json['id']
+
+    response = app.test_client().delete(f'/resume/skill?index={item_id}')
+    assert response.status_code == 200
+    assert response.json[item_id] == example_skills[item_id]
+
+    response_items = app.test_client().get('/resume/skill')
+    assert response_items.json is None
+
+def test_education_delete_index():
+    """
+    Test the successful deletion of education entries at index.
+    """
+    example_education = [
+    {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    },
+    {
+        "course": "Computer Science",
+        "school": "UT",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "97%",
+        "logo": "example-logo.png"
+    }]
+
+    item_id = app.test_client().post('/resume/education',
+                                     json=example_education).json['id']
+
+    response = app.test_client().delete(f'/resume/education?index={item_id}')
+    assert response.status_code == 200
+    assert response.json[item_id] == example_education[item_id]
+
+    response_items = app.test_client().get('/resume/education')
+    assert response_items.json is None
+    


### PR DESCRIPTION
Resolves Issue #18 #19 

Workflow: Addresses indexed skill and education passed in through a DELETE request, then returns the deleted skill and a 200 message if found, and then a 404 with an error message if the index is invalid or skills/education are not found.

Example usage:
BaseURL/resume/education?index=number
BaseURL/resume/skill?index=number

Side Note: Also noticed issues if an index is zero so changed the index to is not null for the get requests as well. Also had to remove error messaging as part of pylint requirements now returns {} if not a valid index for both put and delete as well. 
